### PR TITLE
Fix hash ordering dependence in test.

### DIFF
--- a/lathe-comforts-test/tests.rkt
+++ b/lathe-comforts-test/tests.rkt
@@ -163,8 +163,9 @@
   "Test `w-` with low verbosity.")
 
 (check-equal?
-  (pd / hash-map (hash 'a 1 'b 2) / fn k v
-    (format "(~s, ~s)" k v))
+  (pd / hash-map (hash 'a 1 'b 2) (fn k v
+      (format "(~s, ~s)" k v))
+      #true)
   (list "(a, 1)" "(b, 2)"))
 
 (check-equal?


### PR DESCRIPTION
The order that `hash-map` iterates over is not specified, and on
Racket CS this test fails consistently; see https://github.com/racket/racket/issues/3457

By passing the `try-order?` flag, `hash-map` guarantees that this
test will pass.